### PR TITLE
NO_COLOR env var, version tagging, and perf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BIN = forego
 SRC = $(shell find . -name '*.go' -not -path './vendor/*')
+VERSION = dev
 
 .PHONY: all build clean lint release test
 
@@ -20,4 +21,4 @@ test: lint build
 	go test -v -race -cover ./...
 
 $(BIN): $(SRC)
-	go build -o $@
+	go build -ldflags "-X main.Version=$(VERSION)" -o $@

--- a/outlet.go
+++ b/outlet.go
@@ -12,7 +12,7 @@ import (
 )
 
 type OutletFactory struct {
-	Padding int
+	LeftFormatter string
 
 	sync.Mutex
 }
@@ -80,8 +80,7 @@ func (of *OutletFactory) WriteLine(left, right string, leftC, rightC ct.Color, i
 	if colorize {
 		ct.ChangeColor(leftC, true, ct.None, false)
 	}
-	formatter := fmt.Sprintf("%%-%ds | ", of.Padding)
-	fmt.Printf(formatter, left)
+	fmt.Printf(of.LeftFormatter, left)
 
 	if colorize {
 		if isError {

--- a/start.go
+++ b/start.go
@@ -91,7 +91,7 @@ func init() {
 	cmdStart.Flag.IntVar(&flagShutdownGraceTime, "t", defaultShutdownGraceTime, "shutdown grace time")
 	err := readConfigFile(".forego", &flagProcfile, &flagPort, &flagConcurrency, &flagShutdownGraceTime)
 	handleError(err)
-	colorize = terminal.IsTerminal(int(os.Stdout.Fd()))
+	colorize = os.Getenv("NO_COLOR") == "" && terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func readConfigFile(config_path string, flagProcfile *string, flagPort *int, flagConcurrency *string, flagShutdownGraceTime *int) error {

--- a/start.go
+++ b/start.go
@@ -279,7 +279,7 @@ func runStart(cmd *Command, args []string) {
 	handleError(err)
 
 	of := NewOutletFactory()
-	of.Padding = pf.LongestProcessName(concurrency)
+	of.LeftFormatter = fmt.Sprintf("%%-%ds | ", pf.LongestProcessName(concurrency))
 
 	f := &Forego{
 		outletFactory: of,


### PR DESCRIPTION
Hi. I came across your fork of forego that disables the color output. Thought you might be interested in some more patches in mine.

Three commits in this PR that:

* First adds a Makefile option to inject the version into the final build (previously it was hard coded to "dev")
* Second adds checking `NO_COLOR` env var to disable color output (per https://no-color.org/)
* Third speeds up the stdout processing by only generating the "left" formatter once.

That last once should shave some cycles off every stdout line that is processed. Previously it was calculating the format string for each processed line even though it never changes.

Hopefully can get these all merged into the upstream as well. Figured it makes sense to consolidate things first.